### PR TITLE
Fix `Comparison of different enumeration types` warnings

### DIFF
--- a/Sources/CXXAudioUtilities/include/SFBCAStreamBasicDescription.hpp
+++ b/Sources/CXXAudioUtilities/include/SFBCAStreamBasicDescription.hpp
@@ -57,6 +57,8 @@ public:
 	CAStreamBasicDescription(CommonPCMFormat commonPCMFormat, Float64 sampleRate, UInt32 channelsPerFrame, bool isInterleaved) noexcept
 	: AudioStreamBasicDescription{}
 	{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wanon-enum-enum-conversion"
 		switch(commonPCMFormat) {
 			case CommonPCMFormat::float32:
 				FillOutASBDForLPCM(*this, sampleRate, channelsPerFrame, 32, 32, true, kAudioFormatFlagIsBigEndian == kAudioFormatFlagsNativeEndian, !isInterleaved);
@@ -71,6 +73,7 @@ public:
 				FillOutASBDForLPCM(*this, sampleRate, channelsPerFrame, 32, 32, false, kAudioFormatFlagIsBigEndian == kAudioFormatFlagsNativeEndian, !isInterleaved);
 				break;
 		}
+#pragma clang diagnostic pop
 	}
 
 	// Native overloads
@@ -267,7 +270,10 @@ public:
 	{
 		if(!IsPCM())
 			return false;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wanon-enum-enum-conversion"
 		FillOutASBDForLPCM(format, mSampleRate, mChannelsPerFrame, 32, 32, true, kAudioFormatFlagIsBigEndian == kAudioFormatFlagsNativeEndian, true);
+#pragma clang diagnostic pop
 		return true;
 	}
 

--- a/Sources/CXXAudioUtilities/include/SFBCAStreamBasicDescription.hpp
+++ b/Sources/CXXAudioUtilities/include/SFBCAStreamBasicDescription.hpp
@@ -58,7 +58,7 @@ public:
 	: AudioStreamBasicDescription{}
 	{
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wanon-enum-enum-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 		switch(commonPCMFormat) {
 			case CommonPCMFormat::float32:
 				FillOutASBDForLPCM(*this, sampleRate, channelsPerFrame, 32, 32, true, kAudioFormatFlagIsBigEndian == kAudioFormatFlagsNativeEndian, !isInterleaved);
@@ -271,7 +271,7 @@ public:
 		if(!IsPCM())
 			return false;
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wanon-enum-enum-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 		FillOutASBDForLPCM(format, mSampleRate, mChannelsPerFrame, 32, 32, true, kAudioFormatFlagIsBigEndian == kAudioFormatFlagsNativeEndian, true);
 #pragma clang diagnostic pop
 		return true;


### PR DESCRIPTION
Perhaps not so much of a fix as ignore them, but the issue is in Apple's headers.

Specifically:

>Comparison of different enumeration types ('(unnamed enum at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:503:1)' and '(unnamed enum at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:554:1)') is deprecated