### PR TITLE
Use `const` and `auto` where possible

### DIFF
--- a/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
@@ -74,10 +74,10 @@ bool SFB::AudioRingBuffer::Allocate(const CAStreamBasicDescription& format, uint
 	mCapacityFrames = capacityFrames;
 	mCapacityFramesMask = capacityFrames - 1;
 
-	uint32_t capacityBytes = capacityFrames * format.mBytesPerFrame;
+	const uint32_t capacityBytes = capacityFrames * format.mBytesPerFrame;
 
 	// One memory allocation holds everything- first the pointers followed by the deinterleaved channels
-	uint32_t allocationSize = (capacityBytes + sizeof(uint8_t *)) * format.mChannelsPerFrame;
+	const uint32_t allocationSize = (capacityBytes + sizeof(uint8_t *)) * format.mChannelsPerFrame;
 	uint8_t *memoryChunk = static_cast<uint8_t *>(std::malloc(allocationSize));
 	if(!memoryChunk)
 		return false;
@@ -123,8 +123,8 @@ void SFB::AudioRingBuffer::Reset() noexcept
 
 uint32_t SFB::AudioRingBuffer::FramesAvailableToRead() const noexcept
 {
-	auto writePointer = mWritePointer.load(std::memory_order_acquire);
-	auto readPointer = mReadPointer.load(std::memory_order_acquire);
+	const auto writePointer = mWritePointer.load(std::memory_order_acquire);
+	const auto readPointer = mReadPointer.load(std::memory_order_acquire);
 
 	if(writePointer > readPointer)
 		return writePointer - readPointer;
@@ -134,8 +134,8 @@ uint32_t SFB::AudioRingBuffer::FramesAvailableToRead() const noexcept
 
 uint32_t SFB::AudioRingBuffer::FramesAvailableToWrite() const noexcept
 {
-	auto writePointer = mWritePointer.load(std::memory_order_acquire);
-	auto readPointer = mReadPointer.load(std::memory_order_acquire);
+	const auto writePointer = mWritePointer.load(std::memory_order_acquire);
+	const auto readPointer = mReadPointer.load(std::memory_order_acquire);
 
 	if(writePointer > readPointer)
 		return ((readPointer - writePointer + mCapacityFrames) & mCapacityFramesMask) - 1;
@@ -152,8 +152,8 @@ uint32_t SFB::AudioRingBuffer::Read(AudioBufferList * const bufferList, uint32_t
 	if(!bufferList || frameCount == 0)
 		return 0;
 
-	auto writePointer = mWritePointer.load(std::memory_order_acquire);
-	auto readPointer = mReadPointer.load(std::memory_order_acquire);
+	const auto writePointer = mWritePointer.load(std::memory_order_acquire);
+	const auto readPointer = mReadPointer.load(std::memory_order_acquire);
 
 	uint32_t framesAvailable;
 	if(writePointer > readPointer)
@@ -166,8 +166,8 @@ uint32_t SFB::AudioRingBuffer::Read(AudioBufferList * const bufferList, uint32_t
 
 	auto framesToRead = std::min(framesAvailable, frameCount);
 	if(readPointer + framesToRead > mCapacityFrames) {
-		auto framesAfterReadPointer = mCapacityFrames - readPointer;
-		auto bytesAfterReadPointer = framesAfterReadPointer * mFormat.mBytesPerFrame;
+		const auto framesAfterReadPointer = mCapacityFrames - readPointer;
+		const auto bytesAfterReadPointer = framesAfterReadPointer * mFormat.mBytesPerFrame;
 		FetchABL(bufferList, 0, mBuffers, readPointer * mFormat.mBytesPerFrame, bytesAfterReadPointer);
 		FetchABL(bufferList, bytesAfterReadPointer, mBuffers, 0, (framesToRead - framesAfterReadPointer) * mFormat.mBytesPerFrame);
 	}
@@ -177,7 +177,7 @@ uint32_t SFB::AudioRingBuffer::Read(AudioBufferList * const bufferList, uint32_t
 	mReadPointer.store((readPointer + framesToRead) & mCapacityFramesMask, std::memory_order_release);
 
 	// Set the ABL buffer sizes
-	auto byteSize = static_cast<UInt32>(framesToRead) * mFormat.mBytesPerFrame;
+	const auto byteSize = static_cast<UInt32>(framesToRead) * mFormat.mBytesPerFrame;
 	for(UInt32 bufferIndex = 0; bufferIndex < bufferList->mNumberBuffers; ++bufferIndex)
 		bufferList->mBuffers[bufferIndex].mDataByteSize = byteSize;
 
@@ -189,8 +189,8 @@ uint32_t SFB::AudioRingBuffer::Write(const AudioBufferList * const bufferList, u
 	if(!bufferList || frameCount == 0)
 		return 0;
 
-	auto writePointer = mWritePointer.load(std::memory_order_acquire);
-	auto readPointer = mReadPointer.load(std::memory_order_acquire);
+	const auto writePointer = mWritePointer.load(std::memory_order_acquire);
+	const auto readPointer = mReadPointer.load(std::memory_order_acquire);
 
 	uint32_t framesAvailable;
 	if(writePointer > readPointer)
@@ -203,7 +203,7 @@ uint32_t SFB::AudioRingBuffer::Write(const AudioBufferList * const bufferList, u
 	if(framesAvailable == 0 || (framesAvailable < frameCount && !allowPartial))
 		return 0;
 
-	auto framesToWrite = std::min(framesAvailable, frameCount);
+	const auto framesToWrite = std::min(framesAvailable, frameCount);
 	if(writePointer + framesToWrite > mCapacityFrames) {
 		auto framesAfterWritePointer = mCapacityFrames - writePointer;
 		auto bytesAfterWritePointer = framesAfterWritePointer * mFormat.mBytesPerFrame;

--- a/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
@@ -20,7 +20,7 @@ namespace {
 /// @param bufferList The source buffers
 /// @param srcOffset The byte offset in @c bufferList to begin reading
 /// @param byteCount The maximum number of bytes per non-interleaved buffer to read and write
-inline void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t dstOffset, const AudioBufferList * const _Nonnull bufferList, uint32_t srcOffset, uint32_t byteCount) noexcept
+void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t dstOffset, const AudioBufferList * const _Nonnull bufferList, uint32_t srcOffset, uint32_t byteCount) noexcept
 {
 	for(UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
 		if(srcOffset > bufferList->mBuffers[i].mDataByteSize)
@@ -35,7 +35,7 @@ inline void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t
 /// @param buffers The source buffers
 /// @param srcOffset The byte offset in @c bufferList to begin reading
 /// @param byteCount The maximum number of bytes per non-interleaved buffer to read and write
-inline void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOffset, const uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t srcOffset, uint32_t byteCount) noexcept
+void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOffset, const uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t srcOffset, uint32_t byteCount) noexcept
 {
 	for(UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
 		if(dstOffset > bufferList->mBuffers[i].mDataByteSize)
@@ -47,7 +47,7 @@ inline void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOf
 /// Returns the smallest power of two value greater than @c x
 /// @param x A value in the range [2..2147483648]
 /// @return The smallest power of two greater than @c x
-inline constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
+constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
 {
 	assert(x > 1);
 	assert(x <= ((std::numeric_limits<uint32_t>::max() / 2) + 1));

--- a/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBAudioRingBuffer.cpp
@@ -78,7 +78,7 @@ bool SFB::AudioRingBuffer::Allocate(const CAStreamBasicDescription& format, uint
 
 	// One memory allocation holds everything- first the pointers followed by the deinterleaved channels
 	const uint32_t allocationSize = (capacityBytes + sizeof(uint8_t *)) * format.mChannelsPerFrame;
-	uint8_t *memoryChunk = static_cast<uint8_t *>(std::malloc(allocationSize));
+	auto memoryChunk = static_cast<uint8_t *>(std::malloc(allocationSize));
 	if(!memoryChunk)
 		return false;
 

--- a/Sources/CXXAudioUtilities/SFBCABufferList.cpp
+++ b/Sources/CXXAudioUtilities/SFBCABufferList.cpp
@@ -19,10 +19,10 @@ AudioBufferList * SFB::AllocateAudioBufferList(const CAStreamBasicDescription& f
 	if(format.mBytesPerFrame == 0 || frameCapacity > (std::numeric_limits<UInt32>::max() / format.mBytesPerFrame))
 		return nullptr;
 
-	auto bufferDataSize = format.FrameCountToByteSize(frameCapacity);
-	auto bufferCount = format.ChannelStreamCount();
-	auto bufferListSize = offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * bufferCount);
-	auto allocationSize = bufferListSize + (bufferDataSize * bufferCount);
+	const auto bufferDataSize = format.FrameCountToByteSize(frameCapacity);
+	const auto bufferCount = format.ChannelStreamCount();
+	const auto bufferListSize = offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * bufferCount);
+	const auto allocationSize = bufferListSize + (bufferDataSize * bufferCount);
 
 	auto abl = static_cast<AudioBufferList *>(std::malloc(allocationSize));
 	if(!abl)
@@ -127,13 +127,13 @@ bool SFB::CABufferList::InferFrameLengthFromABL()
 	if(!mBufferList)
 		return false;
 
-	auto buffer0ByteSize = mBufferList->mBuffers[0].mDataByteSize;
+	const auto buffer0ByteSize = mBufferList->mBuffers[0].mDataByteSize;
 	for(UInt32 i = 0; i < mBufferList->mNumberBuffers; ++i) {
 		if(mBufferList->mBuffers[i].mDataByteSize != buffer0ByteSize)
 			throw std::logic_error("inconsistent values for mBufferList->mBuffers[].mBytesPerFrame");
 	}
 
-	auto frameLength = buffer0ByteSize / mFormat.mBytesPerFrame;
+	const auto frameLength = buffer0ByteSize / mFormat.mBytesPerFrame;
 	if(frameLength > mFrameCapacity)
 		throw std::logic_error("mBufferList->mBuffers[0].mBytesPerFrame / mFormat.mBytesPerFrame > mFrameCapacity");
 
@@ -153,9 +153,9 @@ UInt32 SFB::CABufferList::InsertFromBuffer(const CABufferList& buffer, UInt32 re
 	if(readOffset > buffer.mFrameLength || writeOffset > mFrameLength || frameLength == 0 || buffer.mFrameLength == 0)
 		return 0;
 
-	auto framesToInsert = std::min(mFrameCapacity - mFrameLength, std::min(frameLength, buffer.mFrameLength - readOffset));
+	const auto framesToInsert = std::min(mFrameCapacity - mFrameLength, std::min(frameLength, buffer.mFrameLength - readOffset));
 
-	auto framesToMove = mFrameLength - writeOffset;
+	const auto framesToMove = mFrameLength - writeOffset;
 	if(framesToMove) {
 		auto moveToOffset = writeOffset + framesToInsert;
 		for(UInt32 i = 0; i < mBufferList->mNumberBuffers; ++i) {
@@ -183,9 +183,9 @@ UInt32 SFB::CABufferList::TrimAtOffset(UInt32 offset, UInt32 frameLength) noexce
 	if(offset > mFrameLength || frameLength == 0)
 		return 0;
 
-	auto framesToTrim = std::min(frameLength, mFrameLength - offset);
+	const auto framesToTrim = std::min(frameLength, mFrameLength - offset);
 
-	auto framesToMove = mFrameLength - (offset + framesToTrim);
+	const auto framesToMove = mFrameLength - (offset + framesToTrim);
 	if(framesToMove) {
 		auto moveFromOffset = offset + framesToTrim;
 		for(UInt32 i = 0; i < mBufferList->mNumberBuffers; ++i) {
@@ -209,9 +209,9 @@ UInt32 SFB::CABufferList::InsertSilence(UInt32 offset, UInt32 frameLength) noexc
 	if(offset > mFrameLength || frameLength == 0)
 		return 0;
 
-	auto framesToZero = std::min(mFrameCapacity - mFrameLength, frameLength);
+	const auto framesToZero = std::min(mFrameCapacity - mFrameLength, frameLength);
 
-	auto framesToMove = mFrameLength - offset;
+	const auto framesToMove = mFrameLength - offset;
 	if(framesToMove) {
 		auto moveToOffset = offset + framesToZero;
 		for(UInt32 i = 0; i < mBufferList->mNumberBuffers; ++i) {

--- a/Sources/CXXAudioUtilities/SFBCAChannelLayout.cpp
+++ b/Sources/CXXAudioUtilities/SFBCAChannelLayout.cpp
@@ -26,8 +26,8 @@ constexpr size_t ChannelLayoutSize(UInt32 numberChannelDescriptions) noexcept
 /// @throws @c std::bad_alloc
 AudioChannelLayout * CreateChannelLayout(UInt32 numberChannelDescriptions)
 {
-	size_t layoutSize = ChannelLayoutSize(numberChannelDescriptions);
-	AudioChannelLayout *channelLayout = static_cast<AudioChannelLayout *>(std::malloc(layoutSize));
+	const auto layoutSize = ChannelLayoutSize(numberChannelDescriptions);
+	auto channelLayout = static_cast<AudioChannelLayout *>(std::malloc(layoutSize));
 	if(!channelLayout)
 		throw std::bad_alloc();
 
@@ -47,8 +47,8 @@ AudioChannelLayout * CopyChannelLayout(const AudioChannelLayout * _Nullable rhs)
 	if(!rhs)
 		return nullptr;
 
-	size_t layoutSize = ChannelLayoutSize(rhs->mNumberChannelDescriptions);
-	AudioChannelLayout *channelLayout = static_cast<AudioChannelLayout *>(std::malloc(layoutSize));
+	const auto layoutSize = ChannelLayoutSize(rhs->mNumberChannelDescriptions);
+	auto channelLayout = static_cast<AudioChannelLayout *>(std::malloc(layoutSize));
 	if(!channelLayout)
 		throw std::bad_alloc();
 
@@ -333,7 +333,7 @@ CFStringRef SFB::CopyAudioChannelLayoutDescription(const AudioChannelLayout *cha
 				CFArrayAppendValue(array.get(), reinterpret_cast<const void *>(coordinateString.get()));
 			}
 			else {
-				if(auto channelName = CopyChannelLabelName(desc->mChannelLabel, true); channelName)
+				if(const auto channelName = CopyChannelLabelName(desc->mChannelLabel, true); channelName)
 					CFArrayAppendValue(array.get(), reinterpret_cast<const void *>(channelName.get()));
 				else
 					CFArrayAppendValue(array.get(), CFSTR("?"));

--- a/Sources/CXXAudioUtilities/SFBCARingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBCARingBuffer.cpp
@@ -19,7 +19,7 @@ namespace {
 /// @param bufferCount The number of buffers
 /// @param byteOffset The byte offset in @c buffers to begin writing
 /// @param byteCount The number of bytes per non-interleaved buffer to write
-inline void ZeroRange(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t bufferCount, uint32_t byteOffset, uint32_t byteCount)
+void ZeroRange(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t bufferCount, uint32_t byteOffset, uint32_t byteCount)
 {
 	for(uint32_t i = 0; i < bufferCount; ++i)
 		std::memset(buffers[i] + byteOffset, 0, byteCount);
@@ -29,7 +29,7 @@ inline void ZeroRange(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_
 /// @param bufferList The destination buffers
 /// @param byteOffset The byte offset in @c bufferList to begin writing
 /// @param byteCount The maximum number of bytes per non-interleaved buffer to write
-inline void ZeroABL(AudioBufferList * const _Nonnull bufferList, uint32_t byteOffset, uint32_t byteCount)
+void ZeroABL(AudioBufferList * const _Nonnull bufferList, uint32_t byteOffset, uint32_t byteCount)
 {
 	for(UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
 		if(byteOffset > bufferList->mBuffers[i].mDataByteSize)
@@ -44,7 +44,7 @@ inline void ZeroABL(AudioBufferList * const _Nonnull bufferList, uint32_t byteOf
 /// @param bufferList The source buffers
 /// @param srcOffset The byte offset in @c bufferList to begin reading
 /// @param byteCount The maximum number of bytes per non-interleaved buffer to read and write
-inline void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t dstOffset, const AudioBufferList * const _Nonnull bufferList, uint32_t srcOffset, uint32_t byteCount) noexcept
+void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t dstOffset, const AudioBufferList * const _Nonnull bufferList, uint32_t srcOffset, uint32_t byteCount) noexcept
 {
 	for(UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
 		if(srcOffset > bufferList->mBuffers[i].mDataByteSize)
@@ -59,7 +59,7 @@ inline void StoreABL(uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t
 /// @param buffers The source buffers
 /// @param srcOffset The byte offset in @c bufferList to begin reading
 /// @param byteCount The maximum number of bytes per non-interleaved buffer to read and write
-inline void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOffset, const uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t srcOffset, uint32_t byteCount) noexcept
+void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOffset, const uint8_t * const _Nonnull * const _Nonnull buffers, uint32_t srcOffset, uint32_t byteCount) noexcept
 {
 	for(UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
 		if(dstOffset > bufferList->mBuffers[i].mDataByteSize)
@@ -71,7 +71,7 @@ inline void FetchABL(AudioBufferList * const _Nonnull bufferList, uint32_t dstOf
 /// Returns the smallest power of two value greater than @c x
 /// @param x A value in the range [2..2147483648]
 /// @return The smallest power of two greater than @c x
-inline constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
+constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
 {
 	assert(x > 1);
 	assert(x <= ((std::numeric_limits<uint32_t>::max() / 2) + 1));

--- a/Sources/CXXAudioUtilities/SFBCAStreamBasicDescription.cpp
+++ b/Sources/CXXAudioUtilities/SFBCAStreamBasicDescription.cpp
@@ -127,7 +127,7 @@ CFStringRef SFB::CAStreamBasicDescription::CopyFormatDescription() const noexcep
 	CFStringAppendFormat(result, nullptr, CFSTR("%u ch @ %g Hz, "), mChannelsPerFrame, mSampleRate);
 
 	// Shorter description for common formats
-	if(auto commonFormat = CommonFormat(); commonFormat.has_value()) {
+	if(const auto commonFormat = CommonFormat(); commonFormat.has_value()) {
 		switch(commonFormat.value()) {
 			case CommonPCMFormat::int16:
 				CFStringAppendCString(result, "Int16, ", kCFStringEncodingASCII);

--- a/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
@@ -203,8 +203,8 @@ void SFB::RingBuffer::AdvanceWritePosition(uint32_t byteCount) noexcept
 
 const SFB::RingBuffer::ReadBufferPair SFB::RingBuffer::ReadVector() const noexcept
 {
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	uint32_t bytesAvailable;
 	if(writePosition > readPosition)

--- a/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
@@ -72,8 +72,8 @@ void SFB::RingBuffer::Reset() noexcept
 
 uint32_t SFB::RingBuffer::BytesAvailableToRead() const noexcept
 {
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	if(writePosition > readPosition)
 		return writePosition - readPosition;
@@ -83,8 +83,8 @@ uint32_t SFB::RingBuffer::BytesAvailableToRead() const noexcept
 
 uint32_t SFB::RingBuffer::BytesAvailableToWrite() const noexcept
 {
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	if(writePosition > readPosition)
 		return ((readPosition - writePosition + mCapacityBytes) & mCapacityBytesMask) - 1;
@@ -101,8 +101,8 @@ uint32_t SFB::RingBuffer::Read(void * const destinationBuffer, uint32_t byteCoun
 	if(!destinationBuffer || byteCount == 0)
 		return 0;
 
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	uint32_t bytesAvailable;
 	if(writePosition > readPosition)
@@ -113,7 +113,7 @@ uint32_t SFB::RingBuffer::Read(void * const destinationBuffer, uint32_t byteCoun
 	if(bytesAvailable == 0 || (bytesAvailable < byteCount && !allowPartial))
 		return 0;
 
-	auto bytesToRead = std::min(bytesAvailable, byteCount);
+	const auto bytesToRead = std::min(bytesAvailable, byteCount);
 	if(readPosition + bytesToRead > mCapacityBytes) {
 		auto bytesAfterReadPointer = mCapacityBytes - readPosition;
 		std::memcpy(destinationBuffer, mBuffer + readPosition, bytesAfterReadPointer);
@@ -132,8 +132,8 @@ uint32_t SFB::RingBuffer::Peek(void * const destinationBuffer, uint32_t byteCoun
 	if(!destinationBuffer || byteCount == 0)
 		return 0;
 
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	uint32_t bytesAvailable;
 	if(writePosition > readPosition)
@@ -144,7 +144,7 @@ uint32_t SFB::RingBuffer::Peek(void * const destinationBuffer, uint32_t byteCoun
 	if(bytesAvailable == 0 || (bytesAvailable < byteCount && !allowPartial))
 		return 0;
 
-	auto bytesToRead = std::min(bytesAvailable, byteCount);
+	const auto bytesToRead = std::min(bytesAvailable, byteCount);
 	if(readPosition + bytesToRead > mCapacityBytes) {
 		auto bytesAfterReadPointer = mCapacityBytes - readPosition;
 		std::memcpy(destinationBuffer, mBuffer + readPosition, bytesAfterReadPointer);
@@ -161,8 +161,8 @@ uint32_t SFB::RingBuffer::Write(const void * const sourceBuffer, uint32_t byteCo
 	if(!sourceBuffer || byteCount == 0)
 		return 0;
 
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	uint32_t bytesAvailable;
 	if(writePosition > readPosition)
@@ -175,7 +175,7 @@ uint32_t SFB::RingBuffer::Write(const void * const sourceBuffer, uint32_t byteCo
 	if(bytesAvailable == 0 || (bytesAvailable < byteCount && !allowPartial))
 		return 0;
 
-	auto bytesToWrite = std::min(bytesAvailable, byteCount);
+	const auto bytesToWrite = std::min(bytesAvailable, byteCount);
 	if(writePosition + bytesToWrite > mCapacityBytes) {
 		auto bytesAfterWritePointer = mCapacityBytes - writePosition;
 		std::memcpy(mBuffer + writePosition, sourceBuffer, bytesAfterWritePointer);
@@ -212,7 +212,7 @@ const SFB::RingBuffer::ReadBufferPair SFB::RingBuffer::ReadVector() const noexce
 	else
 		bytesAvailable = (writePosition - readPosition + mCapacityBytes) & mCapacityBytesMask;
 
-	auto endOfRead = readPosition + bytesAvailable;
+	const auto endOfRead = readPosition + bytesAvailable;
 
 	if(endOfRead > mCapacityBytes)
 		return { { mBuffer + readPosition, mCapacityBytes - readPosition }, { mBuffer, endOfRead & mCapacityBytes } };
@@ -222,8 +222,8 @@ const SFB::RingBuffer::ReadBufferPair SFB::RingBuffer::ReadVector() const noexce
 
 const SFB::RingBuffer::WriteBufferPair SFB::RingBuffer::WriteVector() const noexcept
 {
-	auto writePosition = mWritePosition.load(std::memory_order_acquire);
-	auto readPosition = mReadPosition.load(std::memory_order_acquire);
+	const auto writePosition = mWritePosition.load(std::memory_order_acquire);
+	const auto readPosition = mReadPosition.load(std::memory_order_acquire);
 
 	uint32_t bytesAvailable;
 	if(writePosition > readPosition)
@@ -233,7 +233,7 @@ const SFB::RingBuffer::WriteBufferPair SFB::RingBuffer::WriteVector() const noex
 	else
 		bytesAvailable = mCapacityBytes - 1;
 
-	auto endOfWrite = writePosition + bytesAvailable;
+	const auto endOfWrite = writePosition + bytesAvailable;
 
 	if(endOfWrite > mCapacityBytes)
 		return { { mBuffer + writePosition, mCapacityBytes - writePosition }, { mBuffer, endOfWrite & mCapacityBytes } };

--- a/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
+++ b/Sources/CXXAudioUtilities/SFBRingBuffer.cpp
@@ -17,7 +17,7 @@ namespace {
 /// Returns the smallest power of two value greater than @c x
 /// @param x A value in the range [2..2147483648]
 /// @return The smallest power of two greater than @c x
-inline constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
+constexpr uint32_t NextPowerOfTwo(uint32_t x) noexcept
 {
 	assert(x > 1);
 	assert(x <= ((std::numeric_limits<uint32_t>::max() / 2) + 1));


### PR DESCRIPTION
Also removes `inline` in some cases